### PR TITLE
幅優先探索 (BFS)で壁かどうかを判定

### DIFF
--- a/include/validate.h
+++ b/include/validate.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validate.h                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yooshima <yooshima@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/28 18:13:53 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/12/22 12:43:18 by yooshima         ###   ########.fr       */
+/*   Updated: 2024/12/22 19:11:55 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,23 +20,42 @@
 
 # define VALID_MAP_CHARS " 01NSEW"
 # define PLAYER_CHARS "NSEW"
+# define WALL_CHAR '1'
 
 typedef enum e_visit_status
 {
-	NOT_VISITED = 0,
-	VISITED = 1
-}		t_visit_status;
+	NOT_VISITED = '0',
+	VISITED = '1'
+}			t_visit_status;
 
-int		validate_args(int argc, char **argv);
-bool	validate_line(const char *line, t_game *game, t_cub_el *cub_el_flag);
-bool	validate_map(t_map *map);
-void	validate_cub_file(t_game *game, t_cub_el *cub_el_flag);
-bool	check_map_characters(t_map *map);
-bool	check_player_position(t_map *map);
-bool	check_map_closed(t_map *map);
-bool	has_two_or_more_walls_in_row(char *row);
-bool	has_two_or_more_walls_in_column(char **map, size_t column_index,
-			size_t height);
-bool	is_surrounded_by_walls(t_map *map, size_t i, size_t j, char **visited);
+typedef struct s_node
+{
+	size_t	i;
+	size_t	j;
+}			t_node;
+
+typedef struct s_check_params
+{
+	t_map	*map;
+	t_node	current;
+	t_node	*queue;
+	size_t	*front;
+	size_t	*rear;
+	char	**visited;
+}			t_check_params;
+
+int			validate_args(int argc, char **argv);
+bool		validate_line(const char *line, t_game *game,
+				t_cub_el *cub_el_flag);
+bool		validate_map(t_map *map);
+void		validate_cub_file(t_game *game, t_cub_el *cub_el_flag);
+bool		check_map_characters(t_map *map);
+bool		check_player_position(t_map *map);
+bool		check_map_closed(t_map *map);
+bool		has_two_or_more_walls_in_row(char *row);
+bool		has_two_or_more_walls_in_column(char **map, size_t column_index,
+				size_t height);
+bool		is_surrounded_by_walls(t_map *map, size_t i, size_t j,
+				char **visited);
 
 #endif

--- a/src/validate/validate_map_wall_analyzer.c
+++ b/src/validate/validate_map_wall_analyzer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   validate_map_wall_analyzer.c                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yooshima <yooshima@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/28 18:27:28 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/12/22 18:41:19 by yooshima         ###   ########.fr       */
+/*   Updated: 2024/12/22 19:10:42 by ootsuboyosh      ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,42 +18,78 @@
 
 static bool	is_map_edge(t_map *map, size_t i, size_t j)
 {
-	if (((i == 0 || j == 0 || i == (map->height - 1) \
-			|| j == (map->width - 1))) && map->data[i][j] == '0')
-		return (true);
+	if ((i == 0 || j == 0 || i == (map->height - 1) || j == (map->width - 1)))
+	{
+		if (map->data[i][j] == '0')
+			return (true);
+	}
 	return (false);
 }
 
-static bool	is_wall(t_map *map, size_t i, size_t j)
+static void	check_neighbors(t_check_params *params)
 {
-	if (i >= map->height || j >= map->width)
-		return (false);
-	return (map->data[i][j] == '1');
+	size_t				new_i;
+	size_t				new_j;
+	size_t				d;
+	static const int	directions[4][2] = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+
+	d = 0;
+	while (d < 4)
+	{
+		new_i = params->current.i + directions[d][0];
+		new_j = params->current.j + directions[d][1];
+		if (new_i >= params->map->height || new_j >= params->map->width)
+		{
+			d++;
+			continue ;
+		}
+		if (params->visited[new_i][new_j] == VISITED
+			|| params->map->data[new_i][new_j] == WALL_CHAR)
+		{
+			d++;
+			continue ;
+		}
+		params->visited[new_i][new_j] = VISITED;
+		params->queue[(*params->rear)++] = (t_node){new_i, new_j};
+		d++;
+	}
 }
 
-static bool	explore_neighbors(t_map *map, size_t i, size_t j, char **visited)
+static bool	process_queue(t_check_params *params)
 {
-	if (i > 0 && !is_surrounded_by_walls(map, i - 1, j, visited))
-		return (false);
-	if ((i + 1) < map->height && !is_surrounded_by_walls(map, i + 1, j,
-			visited))
-		return (false);
-	if (j > 0 && !is_surrounded_by_walls(map, i, j - 1, visited))
-		return (false);
-	if ((j + 1) < map->width && !is_surrounded_by_walls(map, i, j + 1,
-			visited))
-		return (false);
+	t_node	current;
+
+	while (*(params->front) < *(params->rear))
+	{
+		current = params->queue[(*(params->front))++];
+		params->current = current;
+		if (is_map_edge(params->map, current.i, current.j))
+		{
+			free(params->queue);
+			return (false);
+		}
+		check_neighbors(params);
+	}
+	free(params->queue);
 	return (true);
 }
 
-bool	is_surrounded_by_walls(t_map *map, size_t i, size_t j, char **visited)
+bool	is_surrounded_by_walls(t_map *map, size_t start_i, size_t start_j,
+		char **visited)
 {
-	if (is_map_edge(map, i, j))
+	t_node			*queue;
+	size_t			front;
+	size_t			rear;
+	t_check_params	params;
+
+	front = 0;
+	rear = 0;
+	queue = malloc((map->height * map->width) * sizeof(t_node));
+	if (!queue)
 		return (false);
-	if (is_wall(map, i, j))
-		return (true);
-	if (visited[i][j] == VISITED)
-		return (true);
-	visited[i][j] = VISITED;
-	return (explore_neighbors(map, i, j, visited));
+	queue[rear++] = (t_node){start_i, start_j};
+	visited[start_i][start_j] = VISITED;
+	params = (t_check_params){map, {start_i, start_j}, queue, &front, &rear,
+		visited};
+	return (process_queue(&params));
 }


### PR DESCRIPTION
fix #54 
プレイヤーの位置から東西南北に検索する幅優先探索というものがあるらしいので
そちらを参考にしました
引数の数が5つ以上になってしまったので構造体で管理するようにしています