### PR TITLE
:bug: errorが2多重出力される問題の修正 func check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
         "stdio.h": "c",
         "validate.h": "c",
         "init.h": "c",
-        "libft.h": "c"
+        "libft.h": "c",
+        "stdbool.h": "c"
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = cub3D
 
 CC = cc
-CFLAGS = -Wall -Wextra -Werror -Iinclude -I./libft -I./minilibx
+CFLAGS = -Wall -Wextra -Werror -Iinclude -I./libft -I./minilibx -O0
 
 SRCS = src/main.c \
        src/display/display_info.c src/display/display_player.c \

--- a/include/parse.h
+++ b/include/parse.h
@@ -6,7 +6,7 @@
 /*   By: yooshima <yooshima@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/15 14:34:31 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/12/24 19:35:11 by yooshima         ###   ########.fr       */
+/*   Updated: 2024/12/25 23:58:54 by yooshima         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,8 +22,9 @@
 # define MAP_INITIAL_SIZE 10
 # define TEXTURE_IDENTIFIER_LENGTH 3
 # define RESIZE_FACTOR 2
-# define WHITESPACE_CHARS " \t\n\r\v\f"
+# define FD_ERROR -1
 # define FD_CLOSED -2
+# define WHITESPACE_CHARS " \t\n\r\v\f"
 
 bool	parse_color_line(const char *line, int color[3]);
 void	parse_cub_file(const char *filename, t_game *game);

--- a/src/init/init_data.c
+++ b/src/init/init_data.c
@@ -6,11 +6,12 @@
 /*   By: yooshima <yooshima@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/15 15:47:36 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/12/23 21:11:12 by yooshima         ###   ########.fr       */
+/*   Updated: 2024/12/25 23:55:05 by yooshima         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "init.h"
+#include "parse.h"
 #include "ray.h"
 #include <math.h>
 
@@ -31,6 +32,7 @@ void	init_game_data(t_cub3d *game_data)
 		game_data->colors.ceiling[i] = -1;
 		i++;
 	}
+	game_data->map.parse.fd = FD_CLOSED;
 }
 
 void	init_game(t_game *game)

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -6,7 +6,7 @@
 /*   By: yooshima <yooshima@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/12/06 17:23:51 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/12/24 19:35:35 by yooshima         ###   ########.fr       */
+/*   Updated: 2024/12/26 00:02:12 by yooshima         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -68,7 +68,7 @@ char	*read_and_trim_line(int fd)
 
 void	wrap_close(int *fd)
 {
-	if (*fd != FD_CLOSED && close(*fd) == -1)
+	if (*fd != FD_CLOSED && *fd != FD_ERROR && close(*fd) == -1)
 		print_error_exit("Failed to close file\n");
 	*fd = FD_CLOSED;
 }

--- a/src/util/util_error.c
+++ b/src/util/util_error.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   util_error.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ootsuboyoshiyuki <ootsuboyoshiyuki@stud    +#+  +:+       +#+        */
+/*   By: yooshima <yooshima@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/28 15:55:25 by ootsuboyosh       #+#    #+#             */
-/*   Updated: 2024/12/07 16:27:45 by ootsuboyosh      ###   ########.fr       */
+/*   Updated: 2024/12/26 00:00:45 by yooshima         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 


### PR DESCRIPTION
`nm -u obj/**/*.o | grep U | sort | uniq`
上記のコマンドで確認するとmemcpyが呼ばれたことになっているが実際の関数内部で読んだ形跡はないため、問題はないと思う

errorが多重出力される問題は、openが失敗した場合に、fd = -1になりエラープリントの条件を通過していたため、その場合の条件を追加した。
